### PR TITLE
Increase OpenAI client timeout handling

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -6,7 +6,9 @@ $topicService = new TopicService();
 $settingService = new SettingService();
 $openaiOptions = array(
     'base_url' => OPENAI_BASE_URL,
-    'relay_token' => OPENAI_RELAY_TOKEN
+    'relay_token' => OPENAI_RELAY_TOKEN,
+    'timeout' => OPENAI_TIMEOUT,
+    'connect_timeout' => OPENAI_CONNECT_TIMEOUT
 );
 $openaiClient = new OpenAIClient(OPENAI_API_KEY, $openaiOptions);
 $generator = new ArticleGenerator($openaiClient);

--- a/config.php
+++ b/config.php
@@ -65,6 +65,8 @@ define('DB_PASS', isset($ENV['DB_PASS']) ? $ENV['DB_PASS'] : '');
 define('OPENAI_API_KEY', isset($ENV['OPENAI_API_KEY']) ? $ENV['OPENAI_API_KEY'] : '');
 define('OPENAI_BASE_URL', isset($ENV['OPENAI_BASE_URL']) && trim($ENV['OPENAI_BASE_URL']) !== '' ? rtrim($ENV['OPENAI_BASE_URL'], '/') : 'https://api.openai.com/v1');
 define('OPENAI_RELAY_TOKEN', isset($ENV['OPENAI_RELAY_TOKEN']) ? $ENV['OPENAI_RELAY_TOKEN'] : '');
+define('OPENAI_TIMEOUT', (isset($ENV['OPENAI_TIMEOUT']) && is_numeric($ENV['OPENAI_TIMEOUT']) && (int)$ENV['OPENAI_TIMEOUT'] > 0) ? (int)$ENV['OPENAI_TIMEOUT'] : 120);
+define('OPENAI_CONNECT_TIMEOUT', (isset($ENV['OPENAI_CONNECT_TIMEOUT']) && is_numeric($ENV['OPENAI_CONNECT_TIMEOUT']) && (int)$ENV['OPENAI_CONNECT_TIMEOUT'] > 0) ? (int)$ENV['OPENAI_CONNECT_TIMEOUT'] : 30);
 define('BASE_URL', $baseUrl);
 define('ADMIN_LOGIN', isset($ENV['ADMIN_LOGIN']) ? $ENV['ADMIN_LOGIN'] : 'admin');
 define('ADMIN_PASSWORD', isset($ENV['ADMIN_PASSWORD']) ? $ENV['ADMIN_PASSWORD'] : 'admin');

--- a/cron.php
+++ b/cron.php
@@ -14,7 +14,9 @@ $topicService = new TopicService();
 $articleService = new ArticleService();
 $openaiOptions = array(
     'base_url' => OPENAI_BASE_URL,
-    'relay_token' => OPENAI_RELAY_TOKEN
+    'relay_token' => OPENAI_RELAY_TOKEN,
+    'timeout' => OPENAI_TIMEOUT,
+    'connect_timeout' => OPENAI_CONNECT_TIMEOUT
 );
 $openaiClient = new OpenAIClient(OPENAI_API_KEY, $openaiOptions);
 $generator = new ArticleGenerator($openaiClient);


### PR DESCRIPTION
## Summary
- extend the OpenAI client request method to temporarily raise the execution time limit while awaiting long-running responses and restore the original limit afterwards
- surface configurable request and connection timeout values via environment settings and thread them through client instantiation

## Testing
- php -l core/OpenAIClient.php
- php -l admin/index.php
- php -l cron.php

------
https://chatgpt.com/codex/tasks/task_e_68dc52ed0e08832ba272c9c72fd52a66